### PR TITLE
Fix training calls and GPU setup

### DIFF
--- a/src/game/agent_speed.py
+++ b/src/game/agent_speed.py
@@ -8,7 +8,9 @@ from controller import GameController
 from collections import deque
 import random
 from learning import SpeedLearning
-from training import train_speed_agent
+# The correct training function is named `train_speed`. Import it
+# instead of the non-existent `train_speed_agent`.
+from training import train_speed
 
 from game_capture import GameEnvironment
         
@@ -89,7 +91,7 @@ class Agent:
         Parameters:
         - num_episodes (int): The number of episodes to train the agent for.
         """
-        train_speed_agent(self, num_episodes)
+        train_speed(self, num_episodes)
 
     def save_weights(self, path):
         """

--- a/src/game/agent_steering.py
+++ b/src/game/agent_steering.py
@@ -6,7 +6,9 @@ from controller import GameController
 from tensorflow.python.keras.models import load_model
 from collections import deque
 from learning import SteeringLearning
-from training import train_steering_agent
+# The training module exposes a function named `train_steering`.
+# Import that function instead of the non-existent `train_steering_agent`.
+from training import train_steering
 
 class Agent:
     def __init__(self, game_env, input_dims, n_actions, mem_size, eps, eps_min, eps_dec, gamma, q_eval_name, q_target_name, replace):

--- a/src/game/tf_config.py
+++ b/src/game/tf_config.py
@@ -9,6 +9,8 @@ def configure_tensorflow():
         try:
             for gpu in gpus:
                 tf.config.experimental.set_memory_growth(gpu, True)
-            tf.config.experimental.set_visible_devices(gpus[1], 'GPU')
+            # Select the first GPU if available to avoid index errors on
+            # systems with a single GPU.
+            tf.config.experimental.set_visible_devices(gpus[0], 'GPU')
         except RuntimeError as e:
             print(e)


### PR DESCRIPTION
## Summary
- fix incorrect training function imports in agent modules
- use first GPU in `configure_tensorflow` to avoid index errors

## Testing
- `python -m py_compile src/game/agent_steering.py src/game/agent_speed.py src/game/tf_config.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68503d8eadb0832aa06f971d9eda82d3