### PR TITLE
Fix typo in notebook error message

### DIFF
--- a/src/utils/utils.ipynb
+++ b/src/utils/utils.ipynb
@@ -103,7 +103,7 @@
      "evalue": "",
      "output_type": "error",
      "traceback": [
-      "\u001b[1;31mThe Kernel crashed while executing code in the the current cell or a previous cell. Please review the code in the cell(s) to identify a possible cause of the failure. Click <a href='https://aka.ms/vscodeJupyterKernelCrash'>here</a> for more info. View Jupyter <a href='command:jupyter.viewOutput'>log</a> for further details."
+      "\u001b[1;31mThe Kernel crashed while executing code in the current cell or a previous cell. Please review the code in the cell(s) to identify a possible cause of the failure. Click <a href='https://aka.ms/vscodeJupyterKernelCrash'>here</a> for more info. View Jupyter <a href='command:jupyter.viewOutput'>log</a> for further details."
      ]
     }
    ],


### PR DESCRIPTION
## Summary
- fix doubled word in src/utils/utils.ipynb

## Testing
- `python -m py_compile $(find . -name '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685924b813d0832aa45ad71e3beb381e