### PR TITLE
Add epsilon parameters to learning classes

### DIFF
--- a/src/game/agents.py
+++ b/src/game/agents.py
@@ -61,7 +61,17 @@ class SteeringAgent(BaseAgent):
         return action
 
     def learn(self, action):
-        self.learning = SteeringLearning(self.Q_eval, self.Q_target, self.memory, self.gamma, self.replace, self.expected_shape)
+        self.learning = SteeringLearning(
+            self.Q_eval,
+            self.Q_target,
+            self.memory,
+            self.gamma,
+            self.replace,
+            self.expected_shape,
+            self.eps,
+            self.eps_min,
+            self.eps_dec,
+        )
         self.learning.learn(action)
 
     def simulate_action(self, action):
@@ -81,7 +91,17 @@ class SpeedAgent(BaseAgent):
         return chosen_action
 
     def learn(self, action):
-        self.learning = SpeedLearning(self.Q_eval, self.Q_target, self.memory, self.gamma, self.replace, self.expected_shape)
+        self.learning = SpeedLearning(
+            self.Q_eval,
+            self.Q_target,
+            self.memory,
+            self.gamma,
+            self.replace,
+            self.expected_shape,
+            self.eps,
+            self.eps_min,
+            self.eps_dec,
+        )
         self.learning.learn(action)
 
     def simulate_action(self, action):

--- a/src/game/learning.py
+++ b/src/game/learning.py
@@ -3,7 +3,8 @@ import numpy as np
 import random
 
 class BaseLearning:
-    def __init__(self, Q_eval, Q_target, memory, gamma, replace, expected_shape):
+    def __init__(self, Q_eval, Q_target, memory, gamma, replace, expected_shape,
+                 eps, eps_min, eps_dec):
         self.Q_eval = Q_eval
         self.Q_target = Q_target
         self.memory = memory
@@ -11,6 +12,10 @@ class BaseLearning:
         self.replace = replace
         self.expected_shape = expected_shape
         self.learn_step = 0
+        # Epsilon parameters used in the learning loop
+        self.eps = eps
+        self.eps_min = eps_min
+        self.eps_dec = eps_dec
 
     def preprocess_input_data(self, img):
         return preprocess_input_data(img)


### PR DESCRIPTION
## Summary
- extend `BaseLearning.__init__` with epsilon parameters
- pass epsilon values from agents when creating `SteeringLearning` and `SpeedLearning`

## Testing
- `python -m py_compile src/game/learning.py src/game/agents.py`
- `flake8 src/game/learning.py src/game/agents.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685924bffb8c832a81493c8ee63bf741