### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   commit:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository


### PR DESCRIPTION
Potential fix for [https://github.com/castortroy05/ForzaAIMasters/security/code-scanning/1](https://github.com/castortroy05/ForzaAIMasters/security/code-scanning/1)

The best way to fix the problem is to specify an explicit, minimal `permissions` key in your workflow or job configuration, granting only those privileges required for the workflow to complete its task. In this workflow, the only operation requiring elevated permissions is pushing commits to the repository, so you need `contents: write`. To apply the principle of least privilege, add a `permissions` block with `contents: write` to the job (`commit:`) or at the workflow root (before `jobs:`). Since the only job here is `commit`, either placement works, but setting it at the job level is slightly more precise.

Modify `.github/workflows/commit.yml`, adding the following block under the `jobs: commit:` and above the `runs-on:` line:

```yaml
permissions:
  contents: write
```

No additional external dependencies are required for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
